### PR TITLE
Fix logic in StringValueCollection.TryGetValue

### DIFF
--- a/src/Entity/StringValueCollection.cs
+++ b/src/Entity/StringValueCollection.cs
@@ -167,7 +167,7 @@ public sealed class StringValueCollection : IEnumerable<StringValue>, IEnumerabl
     {
         var sv = this.GetItem(key);
         value = sv;
-        return sv.IsNull;
+        return !sv.IsNull;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Corrected the logic in the TryGetValue method to properly reflect the negation of the IsNull property. This ensures that the method returns the expected boolean value based on the null status of the string value.