### PR TITLE
ResolveEndpoint optimized so that if an IP address is explicitly specified, that IP address is used

### DIFF
--- a/extensions/Sisk.SslProxy/DnsUtil.cs
+++ b/extensions/Sisk.SslProxy/DnsUtil.cs
@@ -15,6 +15,12 @@ namespace Sisk.Ssl;
 
 static class DnsUtil {
     public static IPEndPoint ResolveEndpoint ( ListeningPort port, bool onlyUseIPv4 = false ) {
+
+        // Check if port.Hostname is already an IP address
+        if (IPAddress.TryParse ( port.Hostname, out IPAddress? ipAddress )) {
+            return new IPEndPoint ( ipAddress, port.Port );
+        }
+
         var hostEntry = Dns.GetHostEntry ( port.Hostname );
 
         if (hostEntry.AddressList.Length == 0)


### PR DESCRIPTION
If an IP address is specified directly for the host, ResolveEndpoint should use it directly instead of calling Dns.GetHostEntry, which usually returns a different IP address because when an IP address is specified, Dns.GetHostEntry first looks for a known hostname and then resolves to the IP address for that hostname.