### PR TITLE
When target type is module type, `Router.AutoScanModules` should also instantiate the module type

### DIFF
--- a/src/Routing/Router.SetRoute.cs
+++ b/src/Routing/Router.SetRoute.cs
@@ -40,10 +40,7 @@ public partial class Router {
 
                     Abstract classes should not be included on the router.
                  */
-                if (type == moduleType) {
-                    ;
-                }
-                else if (type.IsAbstract) {
+                if (type.IsAbstract) {
                     if (type.IsSealed) // static
                     {
                         SetObject ( type );


### PR DESCRIPTION
Today I'm using sisk to write a simple http server, and stumble across a weird bug.

First, I defined my controller:
```cs
using Sisk.Core.Http;
using Sisk.Core.Http.Streams;
using Sisk.Core.Routing;

class WsController: RouterModule {
    [RouteGet("/")]
    HttpResponse Index(HttpRequest request) {
        return new HttpResponse("Hello World!");
    }
}
```

And use it with `Router.AutoScanModules` in entry point:  

```cs
internal class Program {
    static async Task Main(string[] args) {
        await StartWebServer("127.0.0.1", 8000);
    }

    public static HttpServerHostContext? App { get; set; }

    static async Task StartWebServer(string ipAddress, int port) {
        using (App = HttpServer.CreateBuilder()
                   .UseListeningPort($"http://{ipAddress}:{port}/")
                   .Build()) {
            App.Router.AutoScanModules<WsController>();
            await App.StartAsync();
        }
    }
}
```

When I launch the program, sisk complains about "No routes has been defined in this router.", and the "/" endpoint response 404 when I access it.  

I found only when I define another base controller(say `BaseController`) that derived from `RouterModule` and make my `WsController` derived from the `BaseController`, then `Router.AutoScanModules<BaseController>` can discover my routes in `WsController`.

I wonder what's the purpose that I cannot use my `WsController` directly since it has already derived from `RouterModule`?  
So I modified some code to make `Router.AutoScanModules<WsController>` work directly.  
Please review my pr and tell me if I'm doing wrong.